### PR TITLE
fix: npm pnpm command to install tailwindcss

### DIFF
--- a/docs/en/docs/guides/development/modern-css/tailwind-css.mdx
+++ b/docs/en/docs/guides/development/modern-css/tailwind-css.mdx
@@ -17,7 +17,7 @@ Install required dependencies:
 <PackageManagerTabs
   command={{
     npm: "npm install -D tailwindcss postcss autoprefixer",
-    pnpm: "pnpm install -D tailwindcss postcss autoprefixer",
+    pnpm: "pnpm add -D tailwindcss postcss autoprefixer",
     yarn: "yarn dlx install -D tailwindcss postcss autoprefixer",
   }}
 />

--- a/docs/en/docs/guides/development/modern-css/tailwind-css.mdx
+++ b/docs/en/docs/guides/development/modern-css/tailwind-css.mdx
@@ -16,8 +16,8 @@ Install required dependencies:
 
 <PackageManagerTabs
   command={{
-    npm: "npx install -D tailwindcss postcss autoprefixer",
-    pnpm: "pnpx install -D tailwindcss postcss autoprefixer",
+    npm: "npm install -D tailwindcss postcss autoprefixer",
+    pnpm: "pnpm install -D tailwindcss postcss autoprefixer",
     yarn: "yarn dlx install -D tailwindcss postcss autoprefixer",
   }}
 />


### PR DESCRIPTION
Hey! This PR is to fix the invalid the command to install Tailwindcss with `npm` and `pnpm`.