### PR TITLE
fix(tailwind.mdx): typo in docs for installing tailwind

### DIFF
--- a/docs/en/docs/integrations/tailwindcss.mdx
+++ b/docs/en/docs/integrations/tailwindcss.mdx
@@ -19,9 +19,9 @@ Install the required dependencies:
 
 <PackageManagerTabs
   command={{
-    npm: "npx install -D tailwindcss postcss autoprefixer",
-    pnpm: "pnpx install -D tailwindcss postcss autoprefixer",
-    yarn: "yarn dlx install -D tailwindcss postcss autoprefixer",
+    npm: "npm install -D tailwindcss postcss autoprefixer",
+    pnpm: "pnpm install -D tailwindcss postcss autoprefixer",
+    yarn: "yarn add -D tailwindcss postcss autoprefixer",
   }}
 />
 


### PR DESCRIPTION
Just a small fix in the docs.