### PR TITLE
fix(browsers-available): note absolute path to Chromium-based browsers

### DIFF
--- a/docs/en/docs/browsers/browsers-available.mdx
+++ b/docs/en/docs/browsers/browsers-available.mdx
@@ -10,19 +10,19 @@ Extension.js provides support for a variety of browsers, enabling you to easily 
 
 ## How Does It Work?
 
-To launch your extension in a specific browser, Extension.js uses the browser's binary path to open a new instance with your extension loaded. For supported browsers (Chrome, Edge, Firefox) you can specify the browser to use by passing the `--browser` flag with the desired browser name. For other browsers, you can specify the path to the browser binary using the `--chromium-binary` or `--gecko-binary` flags, depending on the engine used by the browser.
+To launch your extension in a specific browser, Extension.js uses the browser's binary path to open a new instance with your extension loaded. For supported browsers (Chrome, Edge, Firefox) you can specify the browser to use by passing the `--browser` flag with the desired browser name. For other browsers, you can specify the absolute path to the browser binary using the `--chromium-binary` or `--gecko-binary` flags, depending on the engine used by the browser.
 
 ## Supported Browsers
 
 The following browsers are officially supported by Extension.js:
 
-| Browser            | Usage                                                         |
-| ------------------ | ------------------------------------------------------------- |
-| **Chrome**         | `extension dev --browser=chrome`                              |
-| **Edge**           | `extension dev --browser=edge`                                |
-| **Firefox**        | `extension dev --browser=firefox`                             |
-| **Chromium-based** | `extension dev --chromium-binary=chromium-based=browser-path` |
-| **Gecko-based**    | `extension dev --gecko-binary=gecko-based-browser-path`       |
+| Browser            | Usage                                                                 |
+| ------------------ | --------------------------------------------------------------------- |
+| **Chrome**         | `npx extension dev --browser=chrome`                                  |
+| **Edge**           | `npx extension dev --browser=edge`                                    |
+| **Firefox**        | `npx extension dev --browser=firefox`                                 |
+| **Chromium-based** | `npx extension dev --chromium-binary=/path/to/chromium-based-browser` |
+| **Gecko-based**    | `npx extension dev --gecko-binary=/path/to/gecko-based-browser`       |
 
 Any browser based on the Chromium engine (e.g., Brave or Opera) is supported with the same configuration options as Chrome.
 


### PR DESCRIPTION
The runner didn't find `chromium-browser` in $PATH on my Fedora box, but it did launch it if the absolute path was provided:

```
$ npx extension dev --chromium-binary=chromium-browser
►►► Using own Chromium browser binary chromium-browser. 
►►► my-new-svelte compiled successfully in 2051 ms.
ERROR in Chromium-based ✖︎✖︎✖︎ Can't find the browser path

Either install the missing browser or choose a different one via --browser flag.
NOT FOUND chromium-browser

$ npx extension dev --chromium-binary=$(which chromium-browser)
►►► Using own Chromium browser binary /usr/bin/chromium-browser. 
►►► my-new-svelte compiled successfully in 1983 ms.
►►► Creating new Chromium-based user profile... [==================================================] 100% 0.0s
►►► Chromium-based Extension running in development mode.
```