### PR TITLE
Brave is Chromium based, not Gecko

### DIFF
--- a/docs/en/docs/commands/dev.mdx
+++ b/docs/en/docs/commands/dev.mdx
@@ -113,9 +113,9 @@ Below is a breakdown of the available flags for the `dev` command:
 
 <PackageManagerTabs
   command={{
-    npm: "extension dev ./my-extension --gecko-binary /path/to/brave",
-    pnpm: "extension dev ./my-extension --gecko-binary /path/to/brave",
-    yarn: "extension dev ./my-extension --gecko-binary /path/to/brave",
+    npm: "extension dev ./my-extension --chromium-binary /path/to/brave",
+    pnpm: "extension dev ./my-extension --chromium-binary /path/to/brave",
+    yarn: "extension dev ./my-extension --chromium-binary /path/to/brave",
   }}
 />
 


### PR DESCRIPTION
Fixed a small typo in the docs.