### PR TITLE
fix: Update logo URLs in rspress.config.ts

### DIFF
--- a/rspress.config.ts
+++ b/rspress.config.ts
@@ -20,8 +20,8 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   title: "Extension.js",
   lang: "en",
   logo: {
-    light: "logo-light.png",
-    dark: "logo-dark.png",
+    light: "https://extension.js.org/logo-light.png",
+    dark: "https://extension.js.org/logo-dark.png",
   },
   icon: "https://avatars.githubusercontent.com/u/172809806",
   markdown: {


### PR DESCRIPTION
Currently the logo isn't displayed on any documentation pages (docs subfolder, anything underneath https://extension.js.org/docs/), as the reference is not correctly to the root. Due to different structure, development on localhost, etc. changing it to a different path might not be the best idea.

If you'd like to prevent that absolute path, hosting these two assets in this repository as well instead of crossreferencing them might be an even more resilient approach.

<img width="530" height="349" alt="Missing image on docs pages" src="https://github.com/user-attachments/assets/75789eac-547f-4a60-b3fb-9418d30d4b93" />