### PR TITLE
Correct file reference in docs

### DIFF
--- a/docs/en/docs/features/extension-configuration.mdx
+++ b/docs/en/docs/features/extension-configuration.mdx
@@ -14,7 +14,7 @@ command customization, and support for the massive ecosystem of webpack loaders 
 
 ## How Does It Work?
 
-Adding a `extension.config.js` file at the same level as your `manifest.json` file will
+Adding a `extension.config.js` file at the same level as your `package.json` file will
 extend the capabilities of Extension.js. The config file includes the following keys:
 
 | Key        | Description                                               |


### PR DESCRIPTION
Update documentation to reference 'package.json' instead of 'manifest.json'.