### PR TITLE
fix: update broken links to examples repo

### DIFF
--- a/docs/en/blog/announcing-2-0-0-alpha.mdx
+++ b/docs/en/blog/announcing-2-0-0-alpha.mdx
@@ -12,9 +12,9 @@ To me, "very easy" means very low cognitive effort. It means something is famili
 
 **Version 2.0.0-alpha**
 
-- 30+ templates for popular JavaScript frameworks, CSS pre-processors, and extension APIs. [View on GitHub](https://github.com/extension-js/extension.js/tree/main/examples).
+- 30+ templates for popular JavaScript frameworks, CSS pre-processors, and extension APIs. [View on GitHub](https://github.com/extension-js/examples).
 - Support for adding browser-specific fields in manifest.json that apply only to the target browser, like `{chrome:service_worker: "sw.js"}`
-- `extension.config.js` - For advanced users needing access to the compilation process. [See experimental example](https://github.com/extension-js/extension.js/tree/main/examples/content-extension-config).
+- `extension.config.js` - For advanced users needing access to the compilation process. [See experimental example](https://github.com/extension-js/examples/tree/main/content-extension-config).
 - Faster compilation thanks to [SWC](https://swc.rs/).
 - A revamped documentation site (this one!).
 - A new templates site (coming soon).


### PR DESCRIPTION
## Summary

Updates broken links pointing to the examples repository after recent migration.

## Changes
- Updated URLs to reflect new repository location
- Fixed 404 errors for extension examples