### PR TITLE
docs: add Bun package manager support

### DIFF
--- a/docs/en/docs/features/multi-platform-builds.mdx
+++ b/docs/en/docs/features/multi-platform-builds.mdx
@@ -18,6 +18,7 @@ Run a production build:
     npm: "npx extension build",
     pnpm: "pnpx extension build",
     yarn: "yarn dlx extension build",
+    bun: "bunx extension build",
   }}
 />
 
@@ -35,6 +36,7 @@ You can target a specific browser/engine:
     npm: "npx extension build --browser=chrome",
     pnpm: "pnpx extension build --browser=chrome",
     yarn: "yarn dlx extension build --browser=chrome",
+    bun: "bunx extension build --browser=chrome",
   }}
 />
 
@@ -43,6 +45,7 @@ You can target a specific browser/engine:
     npm: "npx extension build --browser=firefox",
     pnpm: "pnpx extension build --browser=firefox",
     yarn: "yarn dlx extension build --browser=firefox",
+    bun: "bunx extension build --browser=firefox",
   }}
 />
 
@@ -62,6 +65,7 @@ You can also run a build matrix in one command:
     npm: "npx extension build --browser=chrome,edge,firefox",
     pnpm: "pnpx extension build --browser=chrome,edge,firefox",
     yarn: "yarn dlx extension build --browser=chrome,edge,firefox",
+    bun: "bunx extension build --browser=chrome,edge,firefox",
   }}
 />
 
@@ -103,6 +107,7 @@ Generate a distribution zip from each target output with `--zip`:
     npm: "npx extension build --zip",
     pnpm: "pnpx extension build --zip",
     yarn: "yarn dlx extension build --zip",
+    bun: "bunx extension build --zip",
   }}
 />
 
@@ -117,6 +122,7 @@ Customize filename:
     npm: "npx extension build --zip --zip-filename=my-release",
     pnpm: "pnpx extension build --zip --zip-filename=my-release",
     yarn: "yarn dlx extension build --zip --zip-filename=my-release",
+    bun: "bunx extension build --zip --zip-filename=my-release",
   }}
 />
 
@@ -145,6 +151,7 @@ If your code relies on Gecko-style `browser.*` APIs and you need Chromium compat
     npm: "npx extension build --polyfill",
     pnpm: "pnpx extension build --polyfill",
     yarn: "yarn dlx extension build --polyfill",
+    bun: "bunx extension build --polyfill",
   }}
 />
 

--- a/docs/en/docs/getting-started/immediately.mdx
+++ b/docs/en/docs/getting-started/immediately.mdx
@@ -23,6 +23,7 @@ Use samples from the Chrome Extension Samples repository to validate your setup 
     npm: "npx extension@latest dev <sample-name>",
     pnpm: "pnpx extension@latest dev <sample-name>",
     yarn: "yarn dlx extension@latest dev <sample-name>",
+    bun: "bunx extension@latest dev <sample-name>",
   }}
 />
 
@@ -50,6 +51,7 @@ Extension.js supports Microsoft Edge out of the box.
     npm: "npx extension@latest dev <sample-name> --browser=edge",
     pnpm: "pnpx extension@latest dev <sample-name> --browser=edge",
     yarn: "yarn dlx extension@latest dev <sample-name> --browser=edge",
+    bun: "bunx extension@latest dev <sample-name> --browser=edge",
   }}
 />
 
@@ -76,6 +78,7 @@ You can also run Mozilla add-ons in Edge by enabling the polyfill.
     npm: "npx extension@latest dev <addon-name> --browser=edge --polyfill=true",
     pnpm: "pnpx extension@latest dev <addon-name> --browser=edge --polyfill=true",
     yarn: "yarn dlx extension@latest dev <addon-name> --browser=edge --polyfill=true",
+    bun: "bunx extension@latest dev <addon-name> --browser=edge --polyfill=true",
   }}
 />
 


### PR DESCRIPTION
## Summary

Adds Bun package manager support to the multi-platform-builds documentation by adding `bunx` commands to all PackageManagerTabs.

## Changes

- Added `bun: "bunx extension build"` to all PackageManagerTabs in multi-platform-builds.mdx
- Covers all build commands: default build, browser-specific, zip, and polyfill options

## Related Issue

Closes #25

---
*Contributed by [theluckystrike](https://github.com/theluckystrike) | [Zovo](https://zovo.one) — Chrome Extension Studio*