### PR TITLE
docs: fix broken link to templates folder

### DIFF
--- a/docs/en/docs/getting-started/templates.mdx
+++ b/docs/en/docs/getting-started/templates.mdx
@@ -50,7 +50,7 @@ When you run `create --template=<slug>`, Extension.js fetches the selected templ
 
 Find official template sources in the examples repository:
 
-- [extension-js/examples](https://github.com/extension-js/examples/tree/main/examples)
+- [extension-js/examples](https://github.com/extension-js/examples/tree/main/templates)
 
 Template folder names map directly to `--template=<slug>`.
 


### PR DESCRIPTION
The link in the templates documentation currently points to `/tree/main/examples` which returns a 404 error. 

Changed to `/tree/main/templates` which is the correct path to the templates folder.

This fixes issue #354.